### PR TITLE
Moving the repo from a personal fork to OpenSearch repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          repository: saratvemulapalli/OpenSearch
+          repository: opensearch-project/OpenSearch
           ref: feature/extensions
       - name: Publish to Maven Local
         run: |


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

PR: https://github.com/opensearch-project/OpenSearch/pull/2796 has to be merged first.

Moving the repo from a personal fork to OpenSearch repo